### PR TITLE
Temporary fix on how different layer types are ordered on map

### DIFF
--- a/src/lib/components/Charts/SumColumnChart.jsx
+++ b/src/lib/components/Charts/SumColumnChart.jsx
@@ -21,9 +21,9 @@ class SumColumnChart extends React.Component {
     // deifine which break each datum falls into
     let dataBreaks;
     if (breaks) {
-      dataBreaks = layerData.map((d) => {
+      dataBreaks = (layerData.features || layerData).map((d) => {
         for (let b = 0; b < breaks.length; b += 1) {
-          parsedVal = parseColValue(d, column);
+          parsedVal = parseColValue((d.properties || d), column);
           if (parsedVal <= Number(breaks[b])) return b;
         }
         return breaks.length - 1;
@@ -33,8 +33,9 @@ class SumColumnChart extends React.Component {
     // Push the data into categorical buckets
     catCol = chartSpec.level;
     if (catCol === 'district_id' && locations && Object.keys(locations).length) mapCol = true;
-    for (i; i < layerData.length; i += 1) {
-      datum = layerData[i];
+    const activeData = layerData.features || layerData;
+    for (i; i < activeData.length; i += 1) {
+      datum = (activeData[i].properties || activeData[i]);
       if (!dataMap[datum[catCol]]) {
         dataMap[datum[catCol]] = {
           sum: 0,

--- a/src/lib/components/Charts/SumPieChart.jsx
+++ b/src/lib/components/Charts/SumPieChart.jsx
@@ -35,19 +35,20 @@ class SumPieChart extends React.Component {
 
     let dataBreaks;
     if (breaks) {
-      dataBreaks = layerData.map((d) => {
+      dataBreaks = (layerData.features || layerData).map((d) => {
         for (let b = 0; b < breaks.length; b += 1) {
-          if (parseColValue(d, column) <= breaks[b]) return b;
+          if (parseColValue((d.properties || d), column) <= breaks[b]) return b;
         }
         return breaks.length - 1;
       });
     }
 
     // Aggregate data
+    const activeData = layerData.features || layerData;
     if (chartSpec.type === 'status') {
       // loop through dataset
-      for (i; i < layerData.length; i += 1) {
-        datum = layerData[i];
+      for (i; i < activeData.length; i += 1) {
+        datum = activeData[i].properties || activeData[i];
         // check for status category in dataMap
         if (!dataMap[datum[column]]) {
           // create it if it doesn't exist
@@ -61,8 +62,8 @@ class SumPieChart extends React.Component {
         dataMap[datum[column]].count += 1;
       }
     } else if (chartSpec.type === 'breaks') {
-      for (i; i < layerData.length; i += 1) {
-        datum = layerData[i];
+      for (i; i < activeData.length; i += 1) {
+        datum = activeData[i].properties || activeData[i];
         dBreak = dataBreaks[i];
         if (!dataMap[dBreak]) {
           dataMap[dBreak] = {

--- a/src/lib/components/DetailView/DetailView.js
+++ b/src/lib/components/DetailView/DetailView.js
@@ -57,7 +57,8 @@ class DetailView extends Component {
     const { layerObj, properties, spec, detailView, mapId } = nextProps;
     if (!layerObj || !spec || !properties || !detailView) {
       this.setState({ UID: null });
-    } else if (nextProps.timeSeriesObj && detailView) {
+    } else if ((nextProps.timeSeriesObj && detailView) && 
+        (nextProps.timeSeriesObj.layerId === layerObj.id)) {
       const { timeSeriesObj, layerObj, spec, properties } = nextProps;
       const { UID, title, subTitle, basicInfo } = detailView;
       const newParsedBasicInfo = [];

--- a/src/lib/components/DetailView/DetailView.js
+++ b/src/lib/components/DetailView/DetailView.js
@@ -28,7 +28,7 @@ const mapStateToProps = (state, ownProps) => {
     properties: detailView && detailView.properties,
     spec: detailView && detailView.spec,
     children: ownProps.children,
-  };
+  }
 }
 
 class DetailView extends Component {
@@ -113,21 +113,20 @@ class DetailView extends Component {
   }
 
   render() {
-    
     const { UID, spec, title, subTitle, parsedBasicInfo } = this.state;
     const { mapId, isSplitScreen } = this.props;
     if (this.props.MAP.showFilterPanel || !UID || !spec) return null;
-    console.log("child", this.props.children)
-
     const detailList = [];
     if (spec['basic-info']) {
       let detail;
       for (let i = 0; i < parsedBasicInfo.length; i += 1) {
         detail = parsedBasicInfo[i];
         detailList.push((
-          <li key={i}>
+          detail && detail.icon ?
+          (<li key={i}>
             <i data-balloon={detail.alt} data-balloon-pos="up">
               <span
+                
                 className={detail.icon}
                 style={detail.iconColor ? { color: detail.iconColor } : {}}
               />
@@ -137,7 +136,15 @@ class DetailView extends Component {
             : (
               <span>{`${detail.prefix ? `${detail.prefix}: ` : detail.useAltAsPrefix ? `${detail.alt}: ` : ''}${detail.value}${detail.suffix ? `${detail.suffix}` : ''}`}</span>
             )}
-          </li>
+          </li>) : 
+           (<li key={i}>
+              <b> {`${detail.alt}:`} </b> 
+            {typeof detail.value !== 'string' && detail.value.parser ?
+              Parser(detail.value)
+            : (
+              <span>{detail.value}</span>
+            )}
+          </li>)
         ));
       }
     }

--- a/src/lib/components/DetailView/DetailView.js
+++ b/src/lib/components/DetailView/DetailView.js
@@ -62,12 +62,7 @@ class DetailView extends Component {
       const { UID, title, subTitle, basicInfo } = detailView;
       const newParsedBasicInfo = [];
       let parsedDet;
-      let newProps;
-      (!timeSeriesObj.data.map(d => d[layerObj.source.join[1]]).includes(undefined)) ? 
-       newProps = timeSeriesObj.data.find(d =>
-         d[layerObj.source.join[1]] === properties[layerObj.source.join[0]]):
-        newProps = timeSeriesObj.data.map(d => 
-          d['properties']).find(d => d[layerObj.source.join[1]] === properties[layerObj.source.join[0]])
+      const newProps = timeSeriesObj.data.find(d => (d.properties||d)[layerObj.source.join[1]] === properties[layerObj.source.join[0]]);
       if (!newProps) {
         this.setState({
           UID: null,
@@ -116,7 +111,9 @@ class DetailView extends Component {
   render() {
     const { UID, spec, title, subTitle, parsedBasicInfo } = this.state;
     const { mapId, isSplitScreen } = this.props;
-    if (this.props.MAP.showFilterPanel || !UID || !spec) return null;
+    if (this.props.MAP.showFilterPanel || !UID || !spec) {
+      return null
+    };
     const detailList = [];
     if (spec['basic-info']) {
       let detail;

--- a/src/lib/components/Legend/Legend.js
+++ b/src/lib/components/Legend/Legend.js
@@ -274,7 +274,7 @@ componentWillReceiveProps(nextProps) {
            [...new Set(timeSeriesObj.stops[timeSeriesObj.temporalIndex].map(d => d[1]))] :
            layerObj && layerObj.stops && layerObj.stops[0][0] ?
             [...new Set(layerObj.stops[0][0].map(d => d[1]))] :
-            layer.categories.color;
+            [...new Set(layer.colorStops.map(d => d[1]))];
 
           activeColors.forEach((color, index, activeColors) => {
             const stopsIndex = layerStops ? layerStops.indexOf(color) : -1;
@@ -450,45 +450,61 @@ componentWillReceiveProps(nextProps) {
         ));
       } else if (fillLayerWithBreaks && layer.stops && !layer.parent) {
         const { stopsData, breaks} = layer;
-        const colorLegend = [...new Set(stopsData.map(stop => stop[1]))];
-        const legendSuffix = layer.categories.suffix ? layer.categories.suffix : '';
-        const activeColors =(timeSeriesObj && timeSeriesObj.newColors &&
-          layerObj.aggregate && layerObj.aggregate.timeseries) || (layers 
-            && layers[primaryLayer] && layers[primaryLayer].layers) ? 
-            (timeSeriesObj && timeSeriesObj.newColors) || (layerObj && layerObj.categories 
-            && layerObj.categories.color) : this.state && this.state.timeSeriesObj &&
-             layerObj && layerObj.aggregate && layerObj.aggregate.timeseries ? 
-              this.state.timeSeriesObj.newColors : (layerObj && layerObj.stops) ?
-               [...new Set(layerObj.stops[0][0].map(d => d[1]))]
+          const colorLegend = layer && layer.stopsData && [...new Set(stopsData.map(stop => stop[1]))];
+          const legendSuffix = layer.categories.suffix ? layer.categories.suffix : '';
+
+          const activeColors =(timeSeriesObj && timeSeriesObj.newColors &&
+             layerObj.aggregate && layerObj.aggregate.timeseries) ? 
+              timeSeriesObj.newColors : this.state && this.state.timeSeriesObj &&
+                layerObj && layerObj.aggregate && layerObj.aggregate.timeseries ? 
+                this.state.timeSeriesObj.newColors : (layerObj && layerObj.stops &&
+                   layerObj.stops[0] && layerObj.stops[0][0]) ?
+                [...new Set(layerObj.stops[0][0].map(d => d[1]))]
                 : layer.colors;
-          if (colorLegend && colorLegend.includes('transparent') &&
-          !(activeColors).includes('transparent')) {
+           
+          if (colorLegend && colorLegend.includes('transparent') && !(activeColors).includes('transparent')) {
             activeColors.splice(0, 0, 'transparent');
             breaks.splice(1, 0, breaks[0]);
           }
+          let lastVal;
+          const stopsBreak = (timeSeriesObj && timeSeriesObj.newBreaks && layerObj.aggregate &&
+            layerObj.aggregate.timeseries) ? 
+              timeSeriesObj.newBreaks : (layers[primaryLayer].layers) ?
+              (layerObj && layerObj.categories && layerObj.categories.breaks) :
+               layer.breaks;
+          
+          const lastBreaks = Math.max(...stopsBreak);
+          const layerStops = (timeSeriesObj && timeSeriesObj.stops && 
+            layerObj && layerObj.aggregate && layerObj.aggregate.timeseries) ? 
+           [...new Set(timeSeriesObj.stops[timeSeriesObj.temporalIndex].map(d => d[1]))] :
+           layerObj && layerObj.stops && layerObj.stops[0][0] ?
+            [...new Set(layerObj.stops[0][0].map(d => d[1]))] :
+            [...new Set(layer.colorStops.map(d => d[1]))];
 
-        let lastVal;
-        const stopsBreak = (timeSeriesObj && timeSeriesObj.newBreaks && layerObj.aggregate &&
-          layerObj.aggregate.timeseries)
-          ? timeSeriesObj.newBreaks : layerObj && layerObj.stops 
-          && layerObj.stops[3] ? layerObj.stops[3] : layer.color ;
-        activeColors.forEach((color, index) => {
-          const stopsIndex = layerObj.stops ? layerObj.stops[4].indexOf(color) : -1;
+          activeColors.forEach((color, index, activeColors) => {
+            const stopsIndex = layerStops ? layerStops.indexOf(color) : -1;
+            if (stopsIndex !== -1) {
+              const firstVal = stopsIndex ? stopsBreak[stopsIndex - 1] : 0;
+            
+              if (Object.is(activeColors.length - 1, index)) {
+                // execute last item logic
+                lastVal = lastBreaks;
 
-          if (stopsIndex !== -1) {
-            const firstVal = stopsIndex ? stopsBreak[stopsIndex - 1] : 0;
-            lastVal = stopsBreak[stopsIndex];
-            background.push((
-              <li
-                key={index}
-                className={`background-block-${layer.id}-${mapId}`}
-                data-tooltip={`${typeof formatNum(firstVal, 1) === 'undefined' ? 0 : formatNum(firstVal, 1)}-${typeof formatNum(lastVal, 1) === 'undefined' ? 0 : formatNum(lastVal, 1)}${legendSuffix}`}
-                style={{ background: hexToRgbA(color, 0.9).toString(), width: (100 / activeColors.length) + '%' }}
-              >
-              </li>
-            ));
-          }
-        });
+
+              } else {
+              lastVal = stopsBreak[stopsIndex];
+              }
+              background.push((
+                <li
+                  key={index}
+                  className={`background-block-${layer.id}-${mapId}`}
+                  data-tooltip={`${(typeof formatNum(firstVal, 1) === 'undefined' ? 0 : formatNum(firstVal, 1))}-${(typeof formatNum(lastVal, 1) === 'undefined' ? 0 : formatNum(lastVal, 1))}${legendSuffix}`}
+                  style={{ background: hexToRgbA(color, 0.9).toString(), width: (100 / activeColors.length) + '%' }}
+                >
+                </li>
+              ));
+            }
+          });
 
         legendItems.unshift((
           <div

--- a/src/lib/components/Legend/Legend.js
+++ b/src/lib/components/Legend/Legend.js
@@ -79,8 +79,10 @@ componentWillReceiveProps(nextProps) {
  }
 
  componentDidUpdate(prevProps, prevState) {
-   if (this.props.primaryLayer !== prevProps.primaryLayer && this.props.layers[this.props.primaryLayer].credit) {
-     this.setState({
+   if (this.props.primaryLayer !== prevProps.primaryLayer && this.props.layers &&
+    this.props.layers[this.props.primaryLayer] &&
+     this.props.layers[this.props.primaryLayer].credit) {
+      this.setState({
        primaryLayer: prevProps.primaryLayer
      });
    }

--- a/src/lib/components/Legend/Legend.js
+++ b/src/lib/components/Legend/Legend.js
@@ -332,7 +332,7 @@ componentWillReceiveProps(nextProps) {
         }
         continue;
       }
-      if (circleLayerType) {
+      if (circleLayerType && !fillLayerNoBreaks) {
         legendItems.unshift((
           <div
             id={`legend-${layer.id}-${mapId}`}

--- a/src/lib/components/Legend/Legend.js
+++ b/src/lib/components/Legend/Legend.js
@@ -20,6 +20,7 @@ const mapStateToProps = (state, ownProps) => {
     layersData: buildLayersObj(MAP.layers),
     MAP,
     mapId,
+    activeLayerIds: MAP.activeLayerIds,
     layers : MAP.layers,
     primaryLayer: MAP.primaryLayer,
     showFilterPanel: MAP.showFilterPanel,
@@ -32,6 +33,7 @@ export class Legend extends React.Component {
     super(props);
     this.state = {
       setPrimary: false,
+      primaryLayer: this.props.primaryLayer,
       timeSeriesObj: undefined,
     };
   }
@@ -75,6 +77,14 @@ componentWillReceiveProps(nextProps) {
      }
    }
  }
+
+ componentDidUpdate(prevProps, prevState) {
+   if (this.props.primaryLayer !== prevProps.primaryLayer && this.props.layers[this.props.primaryLayer].credit) {
+     this.setState({
+       primaryLayer: prevProps.primaryLayer
+     });
+   }
+ }
   onUpdatePrimaryLayer(e) {
     e.preventDefault();
     const { dispatch, mapId } = this.props;
@@ -84,7 +94,7 @@ componentWillReceiveProps(nextProps) {
   }
  
   render() {
-    const { layerObj, mapId, lastLayerSelected, timeSeriesObj, layers, primaryLayer, primarySubLayer } = this.props;
+    const { layerObj, mapId, lastLayerSelected, timeSeriesObj, layers, primaryLayer, primarySubLayer, activeLayerIds } = this.props;
     if (!layerObj) {
       return false;
     }
@@ -99,7 +109,20 @@ componentWillReceiveProps(nextProps) {
       const symbolLayer = (layer && layer.credit && layer.categories && layer.categories.shape && layer.type !== 'circle');
       const fillLayerNoBreaks = (layer && layer.credit && layer.categories && layer.categories.breaks === 'no');
       const fillLayerWithBreaks = (layer && layer.credit && layer.type !== 'chart' && layer.type !== 'circle' && layer.categories && layer.categories.breaks === 'yes');
-      const activeLayerSelected = this.props.primaryLayer === layer.id ? 'primary' : '';
+      let activeLegendLayer;
+      let a = activeLayerIds.length;
+      while(a --) {
+        if (layers[activeLayerIds[a]] && layers[activeLayerIds[a]].credit) {
+          activeLegendLayer = activeLayerIds[a];
+          break;
+        }
+      }
+
+      if (this.state.primaryLayer !== primaryLayer && layers[primaryLayer].credit) {
+        activeLegendLayer = primaryLayer;
+      }
+
+      const activeLayerSelected = activeLegendLayer === layer.id  ? 'primary' : '';
 
       let background = [];
 

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -189,7 +189,7 @@ class Map extends Component {
     }
 
     // Move the selected primary layer to the top of the map layers
-    if (!nextLayerObj.layers && nextLayerId !== "pd-details-form" && this.map.getLayer(nextLayerId)) {
+    if (!nextLayerObj.layers && !nextLayerObj['detail-view'] && this.map.getLayer(nextLayerId)) {
       this.map.moveLayer(nextLayerId);
     }
     let layerObj;
@@ -199,7 +199,7 @@ class Map extends Component {
       // If 'layerObj' is not a fill OR the selected primary layer
       if (layerObj.type !== 'fill' && layerObj.id !== nextLayerId && !layerObj.layers && !layerObj.parent) {
         // If 'layerObj' is not the same type as the selected
-        if (layerObj.type !== nextLayerObj.type && nextLayerId !== "pd-details-form") {
+        if (layerObj.type !== nextLayerObj.type && !nextLayerObj['detail-view']) {
           // Move 'layerObj' to the top of the map layers
           if (this.map.getLayer(layerObj.id)) {
             this.map.moveLayer(layerObj.id);

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -48,6 +48,12 @@ const isIE = detectIE();
 window.maps = [];
 
 class Map extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      layersObj: this.props.layersObj,
+    }
+  }
   initMap(accessToken, mapConfig, mapId) {
     if (accessToken && mapConfig) {
       mapboxgl.accessToken = accessToken;
@@ -206,6 +212,10 @@ class Map extends Component {
     const nextlayersObj = activeLayersData.filter(lo => lo.id !== nextLayerId);
     nextlayersObj.push(nextLayerObj);
 
+    this.setState({
+      layersObj: nextlayersObj,
+    });
+
     return true;
   }
   
@@ -230,7 +240,7 @@ class Map extends Component {
     const currentStyle = nextProps.MAP.currentStyle;
     const currentRegion = nextProps.MAP.currentRegion;
     const reloadLayers = nextProps.MAP.reloadLayers;
-    const activelayersData = nextProps.layersObj;
+    const activelayersData = this.state.layersObj;
     const activelayerObj = nextProps.layerObj;
     const primaryLayer = nextProps.MAP.primaryLayer;
     const activeLayerId = nextProps.MAP.activeLayerId;

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -673,7 +673,7 @@ class Map extends Component {
     // todo - move this in to this.props.MAP.sidebarOffset for extensibility
     const { detailView, layerObj, timeSeriesObj } = this.props;
     const detailViewProps = this.props.showDetailView && timeSeriesObj && timeSeriesObj.data && timeSeriesObj.data.length && timeSeriesObj.data.find(d => {
-      return d[layerObj.source.join[1]] === detailView.properties[layerObj.source.join[0]]
+      return (d.properties||d)[layerObj.source.join[1]] === detailView.properties[layerObj.source.join[0]]
     });
     const showDetailView = timeSeriesObj ? detailViewProps && typeof detailViewProps !== undefined : this.props.showDetailView;
     let mapWidth = '100%';

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -189,25 +189,56 @@ class Map extends Component {
     }
 
     // Move the selected primary layer to the top of the map layers
-    if (!nextLayerObj.layers && !nextLayerObj['detail-view'] && this.map.getLayer(nextLayerId)) {
-      this.map.moveLayer(nextLayerId);
+    if (!nextLayerObj.layers && this.map.getLayer(nextLayerId)) {
+      this.map.moveLayer(nextLayerId); 
+      //move icon with detail view to top of the map layers wip
+      if (activeLayersData.find(d => d['detail-view']) && this.map.getLayer(activeLayersData.find(d => d['detail-view']).id)) {
+        this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
+      } 
     }
     let layerObj;
-    // Loop throught all active map layers
+    //Loop throught all active map layers
     for (let i = activeLayersData.length - 1; i >= 0; i -= 1) {
       layerObj = activeLayersData[i];
       // If 'layerObj' is not a fill OR the selected primary layer
       if (layerObj.type !== 'fill' && layerObj.id !== nextLayerId && !layerObj.layers && !layerObj.parent) {
         // If 'layerObj' is not the same type as the selected
-        if (layerObj.type !== nextLayerObj.type && !nextLayerObj['detail-view']) {
+        if (layerObj.type !== nextLayerObj.type) {
           // Move 'layerObj' to the top of the map layers
           if (this.map.getLayer(layerObj.id)) {
             this.map.moveLayer(layerObj.id);
           }
+
         }
       }
     }
-
+    /* Move layer in the : circle, symbol and detailview  based on what shoul move above others wip*/
+    if (activeLayersData) {
+      Object.keys(activeLayersData).forEach((key) => {
+        layerObj = activeLayersData[key];
+        if (layerObj.type === 'circle' && !layerObj.layers && !layerObj.parent) {
+          if (this.map.getLayer(layerObj.id)) {
+            this.map.moveLayer(layerObj.id);
+          }
+        }
+      });
+      Object.keys(activeLayersData).forEach((key)=> {
+        layerObj = activeLayersData[key];
+        if (layerObj.type === 'symbol' && !layerObj.layers && !layerObj.parent) {
+          if(this.map.getLayer(layerObj.id)) {
+            this.map.moveLayer(layerObj.id);
+          }
+        }
+      });
+      Object.keys(activeLayersData).forEach((key) => {
+        layerObj = activeLayersData[key];
+        if(layerObj && layerObj['detail-view'] && !layerObj.layers && !layerObj.parent) {
+          if(this.map.getLayer(layerObj.id)) {
+            this.map.moveLayer(layerObj.id);
+          }
+        }
+      });
+    }
     // Re-order this.state.layersObj array
     const nextlayersObj = activeLayersData.filter(lo => lo.id !== nextLayerId);
     nextlayersObj.push(nextLayerObj);
@@ -215,7 +246,7 @@ class Map extends Component {
     this.setState({
       layersObj: nextlayersObj,
     });
-
+    
     return true;
   }
   
@@ -682,10 +713,14 @@ class Map extends Component {
   render() {
     // todo - move this in to this.props.MAP.sidebarOffset for extensibility
     const { detailView, layerObj, timeSeriesObj } = this.props;
-    const detailViewProps = this.props.showDetailView && timeSeriesObj && timeSeriesObj.data && timeSeriesObj.data.length && timeSeriesObj.data.find(d => {
-      return (d.properties||d)[layerObj.source.join[1]] === detailView.properties[layerObj.source.join[0]]
+    const detailViewProps = this.props.showDetailView && timeSeriesObj &&
+      timeSeriesObj.data && timeSeriesObj.data.length &&
+       timeSeriesObj.data.find(d => {
+      return (d.properties||d)[layerObj.source &&
+         layerObj.source.join[1]] === detailView.properties[layerObj.source && 
+          layerObj.source.join[0]]
     });
-    const showDetailView = timeSeriesObj ? detailViewProps && typeof detailViewProps !== undefined : this.props.showDetailView;
+    const showDetailView = timeSeriesObj && timeSeriesObj.layerId === this.props.primaryLayer ? detailViewProps && typeof detailViewProps !== undefined : this.props.showDetailView;
     let mapWidth = '100%';
     if (this.props.VIEW && this.props.VIEW.splitScreen) {
       mapWidth = this.props.mapId === 'map-1' ? '52%' : '48%';

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -189,7 +189,7 @@ class Map extends Component {
     }
 
     // Move the selected primary layer to the top of the map layers
-    if (!nextLayerObj.layers && this.map.getLayer(nextLayerId)) {
+    if (!nextLayerObj.layers && nextLayerId !== "pd-details-form" && this.map.getLayer(nextLayerId)) {
       this.map.moveLayer(nextLayerId);
     }
     let layerObj;
@@ -199,7 +199,7 @@ class Map extends Component {
       // If 'layerObj' is not a fill OR the selected primary layer
       if (layerObj.type !== 'fill' && layerObj.id !== nextLayerId && !layerObj.layers && !layerObj.parent) {
         // If 'layerObj' is not the same type as the selected
-        if (layerObj.type !== nextLayerObj.type) {
+        if (layerObj.type !== nextLayerObj.type && nextLayerId !== "pd-details-form") {
           // Move 'layerObj' to the top of the map layers
           if (this.map.getLayer(layerObj.id)) {
             this.map.moveLayer(layerObj.id);
@@ -240,7 +240,7 @@ class Map extends Component {
     const currentStyle = nextProps.MAP.currentStyle;
     const currentRegion = nextProps.MAP.currentRegion;
     const reloadLayers = nextProps.MAP.reloadLayers;
-    const activelayersData = this.state.layersObj;
+    const activelayersData = nextProps.layersObj;
     const activelayerObj = nextProps.layerObj;
     const primaryLayer = nextProps.MAP.primaryLayer;
     const activeLayerId = nextProps.MAP.activeLayerId;

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Actions, addPopUp, sortLayers, addChart, buildDetailView, prepareLayer } from 'gisida';
-import { detectIE, buildLayersObj, detailViewData } from '../../utils';
+import { detectIE, buildLayersObj, detailViewData, orderLayers } from '../../utils';
 import './Map.scss';
 
 const mapStateToProps = (state, ownProps) => {
@@ -170,6 +170,7 @@ class Map extends Component {
         if (nextLayerObj) break;
       }
     }
+    let map = this.map;
     if (nextLayerObj && nextLayerId) {
       const parentLayer = layers[nextLayerId];
       if (parentLayer.layers) {
@@ -180,10 +181,7 @@ class Map extends Component {
               this.map.moveLayer(sublayers[s]);
             }
           }
-          if (activeLayersData.find(d => d['detail-view']) &&
-           this.map.getLayer(activeLayersData.find(d => d['detail-view']).id)) {
-            this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
-          } 
+          orderLayers(activeLayersData, map, nextLayerId);
         }
       }
     }
@@ -202,24 +200,27 @@ class Map extends Component {
       } 
     }
     // Loop throught all active map layers
-    for (let i = activeLayersData.length - 1; i >= 0; i -= 1) {
-      layerObj = activeLayersData[i];
-      // If 'layerObj' is not a fill OR the selected primary layer
-      if (layerObj.type !== 'fill' && layerObj.id === nextLayerId && !layerObj.layers && !layerObj.parent) {
-        // If 'layerObj' is not the same type as the selected
-        if (layerObj.type !== nextLayerObj.type) {
-          // Move 'layerObj' to the top of the map layers
-          if (this.map.getLayer(layerObj.id)) {
-            this.map.moveLayer(layerObj.id);
-          }
-          if (activeLayersData.find(d => d['detail-view'])
-           && this.map.getLayer(activeLayersData.find(d => d['detail-view']).id)) {
-            this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
-          } 
+    // for (let i = activeLayersData.length - 1; i >= 0; i -= 1) {
+    //   layerObj = activeLayersData[i];
+      
+    //   // If 'layerObj' is not a fill OR the selected primary layer
+    //   if (layerObj.type !== 'fill' && layerObj.id === nextLayerId && !layerObj.layers && !layerObj.parent) {
+    //     // If 'layerObj' is not the same type as the selected
+    //     if (layerObj.type !== nextLayerObj.type) {
+    //       // Move 'layerObj' to the top of the map layers
+    //       if (this.map.getLayer(layerObj.id)) {
+    //         this.map.moveLayer(layerObj.id);
+    //       }
+    //       if (activeLayersData.find(d => d['detail-view'])
+    //        && this.map.getLayer(activeLayersData.find(d => d['detail-view']).id)) {
+    //         this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
+    //       } 
 
-        }
-      }
-    }
+    //     }
+    //   }
+    // }
+    // Order active layers
+    orderLayers(activeLayersData, map, nextLayerId);
     const nextlayersObj = activeLayersData.filter(lo => lo.id !== nextLayerId);
     nextlayersObj.push(nextLayerObj);
 

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -180,6 +180,10 @@ class Map extends Component {
               this.map.moveLayer(sublayers[s]);
             }
           }
+          if (activeLayersData.find(d => d['detail-view']) &&
+           this.map.getLayer(activeLayersData.find(d => d['detail-view']).id)) {
+            this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
+          } 
         }
       }
     }
@@ -189,6 +193,7 @@ class Map extends Component {
     }
 
     // Move the selected primary layer to the top of the map layers
+    let layerObj;
     if (!nextLayerObj.layers && this.map.getLayer(nextLayerId)) {
       this.map.moveLayer(nextLayerId); 
       //move icon with detail view to top of the map layers wip
@@ -196,50 +201,25 @@ class Map extends Component {
         this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
       } 
     }
-    let layerObj;
-    //Loop throught all active map layers
+    // Loop throught all active map layers
     for (let i = activeLayersData.length - 1; i >= 0; i -= 1) {
       layerObj = activeLayersData[i];
       // If 'layerObj' is not a fill OR the selected primary layer
-      if (layerObj.type !== 'fill' && layerObj.id !== nextLayerId && !layerObj.layers && !layerObj.parent) {
+      if (layerObj.type !== 'fill' && layerObj.id === nextLayerId && !layerObj.layers && !layerObj.parent) {
         // If 'layerObj' is not the same type as the selected
         if (layerObj.type !== nextLayerObj.type) {
           // Move 'layerObj' to the top of the map layers
           if (this.map.getLayer(layerObj.id)) {
             this.map.moveLayer(layerObj.id);
           }
+          if (activeLayersData.find(d => d['detail-view'])
+           && this.map.getLayer(activeLayersData.find(d => d['detail-view']).id)) {
+            this.map.moveLayer(activeLayersData.find(d => d['detail-view']).id);
+          } 
 
         }
       }
     }
-    /* Move layer in the : circle, symbol and detailview  based on what shoul move above others wip*/
-    if (activeLayersData) {
-      Object.keys(activeLayersData).forEach((key) => {
-        layerObj = activeLayersData[key];
-        if (layerObj.type === 'circle' && !layerObj.layers && !layerObj.parent) {
-          if (this.map.getLayer(layerObj.id)) {
-            this.map.moveLayer(layerObj.id);
-          }
-        }
-      });
-      Object.keys(activeLayersData).forEach((key)=> {
-        layerObj = activeLayersData[key];
-        if (layerObj.type === 'symbol' && !layerObj.layers && !layerObj.parent) {
-          if(this.map.getLayer(layerObj.id)) {
-            this.map.moveLayer(layerObj.id);
-          }
-        }
-      });
-      Object.keys(activeLayersData).forEach((key) => {
-        layerObj = activeLayersData[key];
-        if(layerObj && layerObj['detail-view'] && !layerObj.layers && !layerObj.parent) {
-          if(this.map.getLayer(layerObj.id)) {
-            this.map.moveLayer(layerObj.id);
-          }
-        }
-      });
-    }
-    // Re-order this.state.layersObj array
     const nextlayersObj = activeLayersData.filter(lo => lo.id !== nextLayerId);
     nextlayersObj.push(nextLayerObj);
 

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -721,7 +721,9 @@ class Map extends Component {
       timeSeriesObj.data.length &&
       timeSeriesObj.data.find(d => (d.properties || d)[join[1]] === detailView.properties[join[0]]);
 
-    const showDetailViewBool = timeSeriesObj ? detailViewProps && typeof detailViewProps !== undefined : showDetailView;
+    const showDetailViewBool = timeSeriesObj &&
+     timeSeriesObj.layerId === this.props.primaryLayer ?
+      detailViewProps && typeof detailViewProps !== undefined : this.props.showDetailView;
     let mapWidth = '100%';
     if (this.props.VIEW && this.props.VIEW.splitScreen) {
       mapWidth = this.props.mapId === 'map-1' ? '52%' : '48%';

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -191,7 +191,7 @@ class Map extends Component {
     }
 
     // Move the selected primary layer to the top of the map layers
-    let layerObj;
+    // let layerObj;
     if (!nextLayerObj.layers && this.map.getLayer(nextLayerId)) {
       this.map.moveLayer(nextLayerId); 
       //move icon with detail view to top of the map layers wip
@@ -220,6 +220,7 @@ class Map extends Component {
     //   }
     // }
     // Order active layers
+
     orderLayers(activeLayersData, map, nextLayerId);
     const nextlayersObj = activeLayersData.filter(lo => lo.id !== nextLayerId);
     nextlayersObj.push(nextLayerObj);
@@ -346,7 +347,7 @@ class Map extends Component {
              $(`.marker-chart-${layer.id}-${mapId}`).remove();
           }
         });
-        sortLayers(this.map, layers);
+        sortLayers(this.map, layers, (primaryLayer || activeLayerId));
       }
 
       if (this.props.MAP.primaryLayer !== primaryLayer) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -172,3 +172,40 @@ export const parseColValue = (datum, col) => {
 export function deepCopy(x) {
   return JSON.parse(JSON.stringify(x));
 };
+
+export function orderLayers(activeLayersData, map, nextLayerId) {
+  let circles = activeLayersData.filter(d => d['type'] === 'circle'
+     && !d['detail-view']);
+     if (circles.length) {
+       Object.keys(circles).forEach((key) => {
+         if (map.getLayer(circles[key].id)) {
+           map.moveLayer(circles[key].id);
+         }
+       });
+       if (circles.find(c => c.id === nextLayerId) && map.getLayer(nextLayerId)) {
+          map.moveLayer(nextLayerId);
+       }
+     }
+    let symbols = activeLayersData.filter(d => d['type'] === 'symbol' && !d['detail-view']);
+    if (symbols.length) {
+      Object.keys(symbols).forEach((key) => {
+        if (map.getLayer(symbols[key].id)) {
+          map.moveLayer(symbols[key].id)
+        }
+      });
+      if (symbols.find(s => s.id === nextLayerId) && map.getLayer(nextLayerId)) {
+        map.moveLayer(nextLayerId);
+      }
+    }
+    let detailViewActive = activeLayersData.filter(d => d['detail-view']);
+    if (detailViewActive.length) {
+      Object.keys(detailViewActive).forEach((key) => {
+        if (map.getLayer(detailViewActive[key].id)) {
+          map.moveLayer(detailViewActive[key].id);
+        }
+      });
+      if (detailViewActive.find(d => d.id === nextLayerId) && map.getLayer(nextLayerId)) {
+        map.moveLayer(nextLayerId);
+      }
+    }
+}

--- a/test/lib/components/Legend/Legend.test.js
+++ b/test/lib/components/Legend/Legend.test.js
@@ -6,6 +6,12 @@ import toJson from 'enzyme-to-json';
 describe('Legend', () => {
   const layerObj = {"testlayer": "layer1"}
   const timeSeriesObj = {"testTimelayer": "timeLayer1"};
+  const layers = {
+    'test-layer-1': {
+      'visible': true,
+      'credit': "legend"
+    }
+  };
   const layersData = [layerObj];
 
   const componentWrapper = shallow(
@@ -15,6 +21,8 @@ describe('Legend', () => {
       layersData={layersData}
       mapId='map-1'
       primaryLayer=''
+      layers={layers}
+      activeLayerIds={['test-layer-1']}
       MAP={{}}
     />
   );


### PR DESCRIPTION
addresses https://github.com/onaio/lotfa/issues/56#issuecomment-463179181

- Allow layers with profile views take order precedence on map
- cater for layer geojson data when building pie and column chart data

Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>