### PR TITLE
Show legend icon even for non primary layers

### DIFF
--- a/src/lib/components/Legend/Legend.scss
+++ b/src/lib/components/Legend/Legend.scss
@@ -229,9 +229,7 @@
 .legend-row {
   &:not(.primary) {
     cursor: pointer;
-    & > * {
-      display: none;
-    }
+
     b {
       display: inline-block;
       font-weight: normal;


### PR DESCRIPTION
closes https://github.com/onaio/idai-recovery-zimbabwe/issues/25

The icon was active only for the primary layer. Modification was made to allow icons to show also for other non-primary layers

![Screenshot from 2020-09-08 16-08-22](https://user-images.githubusercontent.com/19818819/92480422-8c344380-f1ed-11ea-9411-10832543355e.png)
