### PR TITLE
Superset only auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "dependencies": {
     "@onaio/gatekeeper": "^0.0.20",
+    "@onaio/superset-connector": "^0.0.13",
     "ansi-regex": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "camelcase": "^4.1.0",

--- a/src/lib/components/Callback/Callback.js
+++ b/src/lib/components/Callback/Callback.js
@@ -27,18 +27,18 @@ class Callback extends Component {
   }
 
   async authorizeUser(APP) {
-    const { dispatch, supersetOnlyLogin } = this.props;
+    const { dispatch } = this.props;
     const { AUTH } = this.props.global;
     const accessToken = this.getAccessToken();
     
     const { isAuth, authConfig, user } = await SupAuth.authorizeUser(APP, AUTH, accessToken);
-    if (supersetOnlyLogin && accessToken) {
+    if (APP.supersetOnlyLogin && accessToken) {
       localStorage.setItem('expiry_time', this.getExpiryTime());
       const config = {
         token: accessToken,
         base: APP.supersetBaseClient || APP.supersetBase,
       }  
-      supersetLogin(config, this.history, n=10);
+      supersetLogin(config, this.history);
     }
 
     if (isAuth && authConfig) {

--- a/src/lib/components/Callback/Callback.js
+++ b/src/lib/components/Callback/Callback.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Actions, SupAuth, history } from 'gisida';
 import { getURLSearchParams } from '../../utils';
+import { supersetLogin } from './utils';
 import Cookie from 'js-cookie';
-import superset from '@onaio/superset-connector';
 
 class Callback extends Component {
   constructor(props) {
@@ -30,29 +30,15 @@ class Callback extends Component {
     const { dispatch, supersetOnlyLogin } = this.props;
     const { AUTH } = this.props.global;
     const accessToken = this.getAccessToken();
-    debugger;
     
     const { isAuth, authConfig, user } = await SupAuth.authorizeUser(APP, AUTH, accessToken);
-    debugger;
     if (supersetOnlyLogin && accessToken) {
       localStorage.setItem('expiry_time', this.getExpiryTime());
       const config = {
         token: accessToken,
-        base: APP.supersetBase,
-      }
-      superset.authZ(config, result => {
-				// Notifications to be added in the future
-				if (result.status === 200) {
-          console.log('User logged in to superset');
-          return this.history.push({
-            pathname: '/',
-            search: getURLSearchParams().toString(),
-          });
-				} else {
-          console.log('User not logged in to superset');
-          
-				}
-			});
+        base: APP.supersetBaseClient || APP.supersetBase,
+      }  
+      supersetLogin(config, this.history, n=10);
     }
 
     if (isAuth && authConfig) {

--- a/src/lib/components/Callback/utils.js
+++ b/src/lib/components/Callback/utils.js
@@ -1,0 +1,29 @@
+import { getURLSearchParams } from '../../utils';
+import superset from '@onaio/superset-connector';
+
+/**
+ * Recursive method that trys to login user to superset
+ * If authentication is successeful redirect to dashboard
+ * Else If Number of retrys are less than 10 attempt again
+ * Else Inform user and redirect to home
+*/
+export const supersetLogin = (config, history, n=10) => {
+    superset.authZ(config, result => {
+    if (result.status === 200) {
+      console.log('User logged into superset', config.base);
+      return history.push({
+        pathname: '/dashboard',
+        search: getURLSearchParams().toString(),
+      });
+    } else if (n > 0){
+      console.log('superset retry', config.base);
+      supersetLogin(config, history, n-1);
+    } else {
+      alert('Sorry we couldn\'t log you into superset');
+      return history.push({
+        pathname: '/',
+        search: getURLSearchParams().toString(),
+      });
+    }
+  });
+}

--- a/src/lib/components/DetailView/DetailView.js
+++ b/src/lib/components/DetailView/DetailView.js
@@ -135,25 +135,29 @@ class DetailView extends Component {
     } else if (this.props.LOC && this.props.LOC.location) {
       center = Array.isArray(this.props.LOC.location.center)
         ? {
-          lng: this.props.LOC.location.center[0],
-          lat: this.props.LOC.location.center[1],
-        }
+            lng: this.props.LOC.location.center[0],
+            lat: this.props.LOC.location.center[1],
+          }
         : { ...this.props.LOC.location.center };
       zoom = this.props.LOC.location.zoom;
     } else {
       center = Array.isArray(this.props.APP.mapConfig.center)
         ? {
-          lng: this.props.APP.mapConfig.center[0],
-          lat: this.props.APP.mapConfig.center[1],
-        }
+            lng: this.props.APP.mapConfig.center[0],
+            lat: this.props.APP.mapConfig.center[1],
+          }
         : { ...this.props.APP.mapConfig.center };
       zoom = this.props.LOC.location ? this.props.LOC.location.zoom : this.props.APP.mapConfig.zoom;
     }
-    window.maps[0].easeTo({
+    const index = window.maps.map(m => m['_container'].id).indexOf(this.props.mapId);
+    window.maps[index].easeTo({
       center,
       zoom: zoom,
     });
-    buildDetailView(this.props.mapId, null, null, this.props.dispatch);
+    if (window.maps[index].getLayer(`${this.props.layerObj.id}-highlight`)) {
+      window.maps[index].setPaintProperty(`${this.props.layerObj.id}-highlight`, 'icon-opacity', 0);
+    }
+    buildDetailView(this.props.mapId, null, null, this.props.dispatch, this.props.timeSeriesObj);
   }
 
   render() {
@@ -179,25 +183,25 @@ class DetailView extends Component {
               {typeof detail.value !== 'string' && detail.value.parser ? (
                 Parser(detail.value)
               ) : (
-                  <span>{`${
-                    detail.prefix
-                      ? `${detail.prefix}: `
-                      : detail.useAltAsPrefix
-                        ? `${detail.alt}: `
-                        : ''
-                    }${detail.value}${detail.suffix ? `${detail.suffix}` : ''}`}</span>
-                )}
+                <span>{`${
+                  detail.prefix
+                    ? `${detail.prefix}: `
+                    : detail.useAltAsPrefix
+                    ? `${detail.alt}: `
+                    : ''
+                }${detail.value}${detail.suffix ? `${detail.suffix}` : ''}`}</span>
+              )}
             </li>
           ) : (
-              <li key={i}>
-                <b> {`${detail.alt}:`} </b>
-                {typeof detail.value !== 'string' && detail.value.parser ? (
-                  Parser(detail.value)
-                ) : (
-                    <span>{detail.value}</span>
-                  )}
-              </li>
-            )
+            <li key={i}>
+              <b> {`${detail.alt}:`} </b>
+              {typeof detail.value !== 'string' && detail.value.parser ? (
+                Parser(detail.value)
+              ) : (
+                <span>{detail.value}</span>
+              )}
+            </li>
+          )
         );
       }
     }
@@ -245,8 +249,8 @@ class DetailView extends Component {
             )}
           </div>
         ) : (
-            ''
-          )}
+          ''
+        )}
         {this.state.showImageModal ? (
           <div id="image-modal" className="modal">
             <span className="close" onClick={e => this.closeImageModal(e)}>
@@ -256,8 +260,8 @@ class DetailView extends Component {
             <div id="caption">{title}</div>
           </div>
         ) : (
-            ''
-          )}
+          ''
+        )}
       </div>
     );
   }

--- a/src/lib/components/Filter/Filter.js
+++ b/src/lib/components/Filter/Filter.js
@@ -141,7 +141,11 @@ export class Filter extends Component {
         if (layerFilters[f] instanceof Array) {
           for (o = 0; o < layerFilters[f].length; o += 1) {
             if (layerFilters[f][o] instanceof Array) {
-              if (layerFilters[f][o][0] === '==') {
+              if (
+                layerFilters[f][o][0] === '==' &&
+                filterMap[filterKey].options &&
+                filterMap[filterKey].options[optionKey]
+              ) {
                 filterKey = layerFilters[f][o][1];
                 optionKey = layerFilters[f][o][2];
                 filterMap[filterKey].options[optionKey].enabled = true;

--- a/src/lib/components/Filter/Filter.js
+++ b/src/lib/components/Filter/Filter.js
@@ -23,6 +23,7 @@ const mapStateToProps = (state, ownProps) => {
     MAP,
     mapId,
     oldLayerObj: MAP.oldLayerObjs ? MAP.oldLayerObjs[MAP.primaryLayer] : {},
+    primaryLayer: MAP.primaryLayer,
     isSplitScreen: state.VIEW && state.VIEW.splitScreen,
     FILTER: state.FILTER,
     layerObj: MAP.layers[MAP.filter.layerId],
@@ -33,6 +34,7 @@ const mapStateToProps = (state, ownProps) => {
     showFilterBtn: MAP.filter.layerId && MAP.primaryLayer === MAP.filter.layerId,
     layerData: MAP.layers,
     detailView: MAP.detailView,
+    showDetailView: MAP.detailView && MAP.detailView.model && MAP.detailView.model.UID,
     hasNavBar,
   };
 };
@@ -1006,7 +1008,14 @@ export class Filter extends Component {
     });
   };
   render() {
-    const { isSplitScreen, mapId, layerObj } = this.props;
+    const {
+      isSplitScreen,
+      mapId,
+      layerObj,
+      timeseriesObj,
+      detailView,
+      showDetailView,
+    } = this.props;
     const { filters, isMac, globalSearchField } = this.state;
     const filterIsPrev = layerObj && layerObj.aggregate && layerObj.aggregate.filterIsPrev;
     const filterKeys = filters ? Object.keys(filters) : {};
@@ -1095,12 +1104,28 @@ export class Filter extends Component {
         isClearable = true;
       }
     }
+    const join =
+      layerObj &&
+      ((layerObj['detail-view'] && layerObj['detail-view'].join) ||
+        (layerObj.source && layerObj.source.join));
+    let detailViewProps =
+      join &&
+      showDetailView &&
+      timeseriesObj &&
+      timeseriesObj.data &&
+      timeseriesObj.data.length &&
+      timeseriesObj.data.find(d => (d.properties || d)[join[1]] === detailView.properties[join[0]]);
+
+    const showDetailViewBool =
+      timeseriesObj && timeseriesObj.layerId === this.props.primaryLayer
+        ? detailViewProps && typeof detailViewProps !== undefined
+        : this.props.showDetailView;
 
     const doClear = isFilterable || this.isMapFiltered() || isClearable;
     let sidebarOffset =
       this.props.showFilterPanel && !(layerObj.aggregate && layerObj.aggregate.filterIsPrev)
         ? '260px'
-        : !!this.props.detailView
+        : showDetailViewBool
         ? '355px'
         : '10px';
 

--- a/src/lib/components/Filter/Filter.js
+++ b/src/lib/components/Filter/Filter.js
@@ -145,14 +145,20 @@ export class Filter extends Component {
             if (layerFilters[f][o] instanceof Array) {
               if (
                 layerFilters[f][o][0] === '==' &&
-                filterMap[filterKey].options &&
+                filterMap[filterKey] && filterMap[filterKey].options &&
                 filterMap[filterKey].options[optionKey]
               ) {
                 filterKey = layerFilters[f][o][1];
                 optionKey = layerFilters[f][o][2];
-                filterMap[filterKey].options[optionKey].enabled = true;
-                filterMap[filterKey].options[optionKey].hidden = false;
-                if (!filterMap[filterKey]) filterMap[filterKey].isFiltered = true;
+                if (
+                  filterMap[filterKey] &&
+                  filterMap[filterKey].options &&
+                  filterMap[filterKey].options[optionKey]
+                ) {
+                  filterMap[filterKey].options[optionKey].enabled = true;
+                  filterMap[filterKey].options[optionKey].hidden = false;
+                }
+                // if (!filterMap[filterKey]) filterMap[filterKey].isFiltered = true;
               } else {
                 // To DO: handle quant filter expressions
               }

--- a/src/lib/components/Filter/Filter.js
+++ b/src/lib/components/Filter/Filter.js
@@ -1,14 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-  Actions,
-  generateFilterOptions,
-  generateFilterOptionsPrev,
-  buildFilterState,
-  clearFilterState,
-  lngLat,
-} from 'gisida';
+import { Actions, generateFilterOptions, buildFilterState, clearFilterState, lngLat } from 'gisida';
 import { buildLayersObj } from '../../utils';
 import FilterSelector from './FilterSelector';
 import FilterSelectorPrev from './FilterSelectorPrev';
@@ -312,7 +305,6 @@ export class Filter extends Component {
 
     let filterOptions;
     if (nextProps.timeseriesObj && layerObj.aggregate && layerObj.aggregate.timeseries) {
-      
       filterOptions = generateFilterOptions(timeseriesObj);
     } else if (!timeseriesObj && filterState && filterState.filterOptions) {
       filterOptions = filterState.filterOptions;
@@ -446,7 +438,7 @@ export class Filter extends Component {
     // Update FILTER state
     const filterState = {
       filterOptions: this.props.FILTER[layerId].filterOptions,
-      filters: this.buildFiltersMap(this.props.FILTER[layerId].filterOptions),
+      filters: this.buildFiltersMap(this.props.FILTER[layerId].filterOptions || filterOptions),
       aggregate: {
         ...(oldLayerObj && oldLayerObj.aggregate),
       },
@@ -511,6 +503,8 @@ export class Filter extends Component {
             // loop through option keys
             // check if option is enabled && if optionKey is in select_multiple value
             if (
+              _datum[filterKeys[f]] &&
+              optionKeys[o] &&
               options[optionKeys[o]].enabled &&
               _datum[filterKeys[f]].indexOf(optionKeys[o]) !== -1
             ) {
@@ -865,6 +859,7 @@ export class Filter extends Component {
     }
 
     const { layerObj } = this.props;
+    const layerFilters = this.getLayerFilter(this.state.layerId);
 
     const newLayerObj = {
       aggregate,
@@ -876,7 +871,7 @@ export class Filter extends Component {
       'data-parse': layerObj['data-parse'],
     };
     const newLayerOptions = generateFilterOptions(newLayerObj);
-    const filteredFilters = this.buildFiltersMap(newLayerOptions);
+    const filteredFilters = this.buildFiltersMap(newLayerOptions, layerFilters);
     return this.mergeFilters(filters, filteredFilters, clickedFilterKey);
   };
 

--- a/src/lib/components/Filter/FilterSelector.js
+++ b/src/lib/components/Filter/FilterSelector.js
@@ -83,14 +83,14 @@ export class FilterSelector extends Component {
           <li key={i} className={`optionItem${option.count ? '' : ' inactive'}`}>
             <input
               type="checkbox"
-              id={`${optionKeys[i]}-${mapId}`}
+              id={`${filterKey}-${optionKeys[i]}-${mapId}`}
               value={optionKeys[i]}
               checked={option.enabled}
               onChange={(e) => { this.onFilterOptionClick(e, filterKey); }}
             />
             <label
-              htmlFor={`${optionKeys[i]}-${mapId}`}
-              key={optionKeys[i]}
+              htmlFor={`${filterKey}-${optionKeys[i]}-${mapId}`}
+              key={`${filterKey}-${optionKeys[i]}`}
               data-count={option.count}
               className={`optionLabel${option.enabled ? ' enabled' : ''}`}
               onClick={(e) => { catchZeroCountClicks(e); }}

--- a/src/lib/components/Layer/Layer.js
+++ b/src/lib/components/Layer/Layer.js
@@ -29,6 +29,13 @@ export class Layer extends Component {
       pushLayerToURL(layer, mapId);
     }
     this.props.dispatch(Actions.toggleLayer(mapId, layer.id));
+    if (
+      !MAP.layers[layer.id].visible &&
+      MAP.layers[layer.id].aggregate &&
+      MAP.layers[layer.id].aggregate.timeseries
+    ) {
+      this.props.dispatch(Actions.updateTimeseries(mapId, MAP.timeseries, layer.id));
+    }
     const { center, zoom } = lngLat(LOC, APP);
     if (MAP.layers[layer.id].zoomOnToggle && MAP.layers[layer.id].visible) {
       window.maps.forEach(e => {

--- a/src/lib/components/Layers/Layers.js
+++ b/src/lib/components/Layers/Layers.js
@@ -13,7 +13,7 @@ export class Layers extends Component {
         if (!layer.id) {
           Object.keys(layer).forEach(l => {
             if (layer[l].layers.length) {
-              groups[l] = { isOpen: menuGroupHasVisibleLayers(l, layer[l].layers) };
+              groups[l] = { isOpen: menuGroupHasVisibleLayers(l, layer[l].layers, this.props.activeLayerIds) };
             } else {
               groups[l] = { isOpen: false };
             }
@@ -34,7 +34,7 @@ export class Layers extends Component {
           Object.keys(layer).forEach(groupName => {
             const children = layer[groupName].layers;
 
-            if (menuGroupHasVisibleLayers(groupName, children) && !this.state[groupName].isOpen) {
+            if (menuGroupHasVisibleLayers(groupName, children, this.props.activeLayerIds) && !this.state[groupName].isOpen) {
               this.setState({
                 [groupName]: { isOpen: true },
               });
@@ -158,6 +158,7 @@ export class Layers extends Component {
                   preparedLayers={preparedLayers}
                   auth={this.props.auth}
                   noLayerText={noLayerText}
+                  activeLayerIds={this.props.activeLayerIds}
                 />
               ) : null,
             ]);

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -725,6 +725,7 @@ class Map extends Component {
         if (layerObj && layerObj[HIGHLIGHT_FILTER_PROPERTY] && this.map.getLayer(layerObj.id)) {
           layerObj.filters.highlight[2] = '';
           layerObj.filters.rHighlight[2] = '';
+          this.props.dispatch(Actions.filtersUpdated(this.props.mapId));
           this.buildFilters(layerObj);
         }
       }
@@ -738,14 +739,22 @@ class Map extends Component {
     // Update Layer Filters
     if (this.map && this.props.layerObj && this.map.getLayer(this.props.layerObj.id)) {
       const { FILTER, primaryLayer } = this.props;
+
       if (
-        this.props.MAP.doApplyFilters ||
-        (FILTER &&
-          FILTER[primaryLayer] &&
-          !FILTER[primaryLayer].doUpdate &&
-          prevProps.FILTER[primaryLayer] &&
-          prevProps.FILTER[primaryLayer].doUpdate)
+        (this.props.MAP.doApplyFilters ||
+          (FILTER &&
+            FILTER[primaryLayer] &&
+            !FILTER[primaryLayer].doUpdate &&
+            prevProps.FILTER[primaryLayer] &&
+            prevProps.FILTER[primaryLayer].doUpdate)) &&
+        !!this.props.layerObj &&
+        !!this.map.getLayer(this.props.layerObj.id)
       ) {
+        this.props.dispatch(Actions.filtersUpdated(this.props.mapId));
+        this.buildFilters();
+      }
+
+      if (FILTER && FILTER[primaryLayer] && FILTER[primaryLayer].isFiltered) {
         this.buildFilters();
       }
     }
@@ -806,12 +815,7 @@ class Map extends Component {
   }
 
   buildFilters() {
-    const { layerObj, mapId, timeSeriesObj } = this.props;
-    if (!layerObj || !this.map.getLayer(layerObj.id)) {
-      return false;
-    }
-
-    this.props.dispatch(Actions.filtersUpdated(mapId));
+    const { layerObj, timeSeriesObj } = this.props;
     const layerId = layerObj.id;
 
     const isTsFilter = timeSeriesObj && timeSeriesObj.tsFilter;
@@ -868,7 +872,7 @@ class Map extends Component {
     // if timeseries objects' keys don't match, update the timeseries
     if (timeSeriesObj && prevProps.MAP.currentStyle !== MAP.currentStyle) {
       return true;
-    } 
+    }
     if (
       prevProps.timeseries &&
       Object.keys(prevProps.timeseries).length !== Object.keys(timeseries).length
@@ -903,11 +907,11 @@ class Map extends Component {
 
     return false;
   }
- /**
-  * Utility function sets layout and paint properties based on period matches 
-  * and time slider changes
-  * @param {props} nextProps - new props coming into the component
-  */
+  /**
+   * Utility function sets layout and paint properties based on period matches
+   * and time slider changes
+   * @param {props} nextProps - new props coming into the component
+   */
   updateTimeseriesLayers(nextProps) {
     const { timeSeriesObj, timeseries, layersObj, FILTER } = nextProps ? nextProps : this.props;
     const timeSeriesLayers = Object.keys(timeseries);

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -421,6 +421,7 @@ class Map extends Component {
     const primaryLayer = nextProps.MAP.primaryLayer;
     const activeLayerId = nextProps.MAP.activeLayerId;
     const showLayerSuperset = nextProps.VIEW.showLayerSuperset;
+    const timeSeriesObj = nextProps.timeSeriesObj;
 
     const layers = nextProps.MAP.layers;
     const styles = nextProps.STYLES || [];
@@ -502,6 +503,11 @@ class Map extends Component {
           // Add layer to map if visible
           if (!this.map.getLayer(layer.id) && layer.visible && layer.styleSpec) {
             this.map.addLayer({ ...layer.styleSpec });
+            if (timeSeriesObj && timeSeriesObj.layerId === key) {
+              this.props.dispatch(
+                Actions.updateTimeseries(mapId, nextProps.timeseries, timeSeriesObj.layerId)
+              );
+            }
 
             // if layer has a highlight layer
             if (layer.filters && layer.filters.highlight) {
@@ -553,7 +559,7 @@ class Map extends Component {
               this.map.removeSource(id);
             });
           } else if (this.map.getLayer(layer.id) && nextProps.MAP.reloadLayerId === layer.id) {
-            // 1) remove layer and source 
+            // 1) remove layer and source
             let doUpdateTsLayer =
               nextProps.layerObj.aggregate && nextProps.layerObj.aggregate.timeseries
                 ? true

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -542,7 +542,8 @@ class Map extends Component {
             this.map.getLayer(layer.id) &&
             layer.filters &&
             layer.filters.highlight &&
-            nextProps.primaryLayer !== this.props.primaryLayer
+            nextProps.primaryLayer !== this.props.primaryLayer &&
+            !layer.visible
           ) {
             /**
              * Remove Nutrition sites layer & Highlight layer on map
@@ -552,7 +553,7 @@ class Map extends Component {
               this.map.removeSource(id);
             });
           } else if (this.map.getLayer(layer.id) && nextProps.MAP.reloadLayerId === layer.id) {
-            // 1) remove layer and source
+            // 1) remove layer and source 
             let doUpdateTsLayer =
               nextProps.layerObj.aggregate && nextProps.layerObj.aggregate.timeseries
                 ? true

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -815,10 +815,16 @@ class Map extends Component {
     const filterKeys = Object.keys(layerObj.filters);
     let filter;
     const combinedFilters = [ALL];
+    if (isTsFilter) {
+      layerObj.filters = {
+        ...layerObj.filters,
+        tsFilter: timeSeriesObj.tsFilter,
+      };
+    }
 
     // loop through filters object
     for (let f = 0; f < filterKeys.length; f += 1) {
-      filter = isTsFilter ? timeSeriesObj[filterKeys[f]] : layerObj.filters[filterKeys[f]];
+      filter = layerObj.filters[filterKeys[f]];
 
       if (filterKeys[f] === HIGHLIGHT) {
         // handle highlight filter seperately

--- a/src/lib/components/Map/Map.js
+++ b/src/lib/components/Map/Map.js
@@ -802,7 +802,7 @@ class Map extends Component {
   }
 
   buildFilters() {
-    const { layerObj, mapId } = this.props;
+    const { layerObj, mapId, timeSeriesObj } = this.props;
     if (!layerObj || !this.map.getLayer(layerObj.id)) {
       return false;
     }
@@ -810,13 +810,15 @@ class Map extends Component {
     this.props.dispatch(Actions.filtersUpdated(mapId));
     const layerId = layerObj.id;
 
+    const isTsFilter = timeSeriesObj && timeSeriesObj.tsFilter;
+
     const filterKeys = Object.keys(layerObj.filters);
     let filter;
     const combinedFilters = [ALL];
 
     // loop through filters object
     for (let f = 0; f < filterKeys.length; f += 1) {
-      filter = layerObj.filters[filterKeys[f]];
+      filter = isTsFilter ? timeSeriesObj[filterKeys[f]] : layerObj.filters[filterKeys[f]];
 
       if (filterKeys[f] === HIGHLIGHT) {
         // handle highlight filter seperately

--- a/src/lib/components/Menu/Menu.js
+++ b/src/lib/components/Menu/Menu.js
@@ -40,7 +40,8 @@ const mapStateToProps = (state, ownProps) => {
     legendInfoText: APP.legendInfoText,
     menuScroll: MAP.menuScroll, // Set's scroll position to zero when loading superset Menu component
     showMap: VIEW.showMap, // A flag to determine map/superset view
-    noLayerText: NULL_LAYER_TEXT, // Text to be displayed when a category has no layer pulled from config file
+    noLayerText: NULL_LAYER_TEXT, // Text to be displayed when a category has no layer pulle d from config file
+    activeLayerIds: MAP.activeLayerIds, // list of layer id's for all visible layers
   };
 };
 
@@ -247,6 +248,7 @@ class Menu extends Component {
       hasNavBar,
       useConnectedLayers,
       AUTH,
+      activeLayerIds
     } = this.props;
     const childrenPositionClass = childrenPosition || 'top';
     const marginTop = hasNavBar ? '-80px' : 0;
@@ -415,6 +417,7 @@ class Menu extends Component {
                               auth={AUTH}
                               sector={category.category}
                               hyperLink={hyperLink}
+                              activeLayerIds={activeLayerIds}
                             />
                           ) : this.props.openCategories &&
                             this.props.openCategories.includes(category.category) &&

--- a/src/lib/components/StyleSelector/StyleSelector.js
+++ b/src/lib/components/StyleSelector/StyleSelector.js
@@ -10,7 +10,8 @@ const mapStateToProps = (state, ownProps) => {
   return {
     MAP,
     styles: state.STYLES,
-    showFilterPanel: MAP.showFilterPanel
+    showFilterPanel: MAP.showFilterPanel,
+    activeLayerId: MAP.activeLayerId,
   }
 }
 
@@ -29,8 +30,10 @@ export class StyleSelector extends Component {
   }
 
   changeStyle = (e) => {
+    const { mapId, activeLayerId, dispatch } = this.props;
     const style = e.target.value;
-    this.props.dispatch(Actions.changeStyle(this.props.mapId, style));
+    dispatch(Actions.changeStyle(mapId, style));
+    dispatch(Actions.reloadLayer(mapId, activeLayerId));
   }
 
   render() {


### PR DESCRIPTION
This pr holds code that handles superset login without supplemental authentication used on gisida (map site). It also ensures that layers (menu sub-sector builder not tied to store) work with the latest menu refactors.

- [x] superset only authentication

- [x] Handle superset authentication failures

- [x] Layer compatibility with the current menu tweaks

- [ ] Log failed login attempts to sentry

- [ ] Add tests 